### PR TITLE
Add image OCR sample UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # codex_trial
 
-This repository contains a simple Python application called **guess_number.py**.
+This repository contains two Python applications.
 
-The program picks a random number between 1 and 20 and prompts the user to guess
-until the correct number is entered.
+1. **guess_number.py** - a small guessing game. The program picks a random number between 1 and 20 and prompts the user to guess until the correct number is entered.
 
-Run it with:
+   Run it with:
+   ```bash
+   python guess_number.py
+   ```
 
-```bash
-python guess_number.py
-```
+2. **ocr_app.py** - a minimal UI to extract text from an image using OCR. It opens a window where you can select an image file. Any text detected in the image is shown in the window. Required libraries `pytesseract` and `Pillow` must be installed for the application to work.
+
+   Run it with:
+   ```bash
+   python ocr_app.py
+   ```

--- a/ocr_app.py
+++ b/ocr_app.py
@@ -1,0 +1,43 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+try:
+    from PIL import Image
+    import pytesseract
+except ImportError:
+    Image = None
+    pytesseract = None
+
+def select_image(text_widget):
+    if Image is None or pytesseract is None:
+        messagebox.showerror('Error', 'Required libraries are not installed.')
+        return
+    file_path = filedialog.askopenfilename(
+        title='Select image',
+        filetypes=[('Image Files', '*.png *.jpg *.jpeg *.bmp *.gif')] )
+    if file_path:
+        try:
+            image = Image.open(file_path)
+            extracted = pytesseract.image_to_string(image)
+            text_widget.delete(1.0, tk.END)
+            text_widget.insert(tk.END, extracted)
+        except Exception as e:
+            messagebox.showerror('Error', f'Failed to process image: {e}')
+
+
+def main():
+    root = tk.Tk()
+    root.title('Image Text Reader')
+
+    text_widget = tk.Text(root, wrap=tk.WORD, width=60, height=20)
+    text_widget.pack(padx=10, pady=10)
+
+    btn = tk.Button(root, text='Select Image',
+                    command=lambda: select_image(text_widget))
+    btn.pack(pady=5)
+
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `ocr_app.py` providing a minimal Tkinter UI
- update README with instructions for the new script

## Testing
- `python -m py_compile guess_number.py ocr_app.py`
- `python ocr_app.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6860d3047f4c8328820eecdb24004923